### PR TITLE
Fix couchdblookup on puppet3

### DIFF
--- a/lib/puppet/parser/functions/couchdblookup.rb
+++ b/lib/puppet/parser/functions/couchdblookup.rb
@@ -33,7 +33,8 @@ couchdb server is unreachable from inside a vagrant box).
     key = args[1]
     default = args[2] if args.length >= 3
 
-    if lookupvar('vagrantbox') != :undefined
+    vagrantbox = lookupvar('vagrantbox')
+    unless vagrantbox.nil? or vagrantbox == :undefined
       Puppet.send(:warning, "Bypassing couchdb lookup because 'vagrantbox' fact is defined. couchdblookup() will not return what you expect !")
       return default ? default : :undef
     end


### PR DESCRIPTION
http://docs.puppetlabs.com/guides/custom_functions.html

```
lookupvar returns:

nil (in Puppet 3.x)
:undefined (in Puppet 2.7)
```
