### PR TITLE
Fix couchdblookup() when using strict_variables

### DIFF
--- a/lib/puppet/parser/functions/couchdblookup.rb
+++ b/lib/puppet/parser/functions/couchdblookup.rb
@@ -33,10 +33,13 @@ couchdb server is unreachable from inside a vagrant box).
     key = args[1]
     default = args[2] if args.length >= 3
 
-    vagrantbox = lookupvar('vagrantbox')
-    unless vagrantbox.nil? or vagrantbox == :undefined
-      Puppet.send(:warning, "Bypassing couchdb lookup because 'vagrantbox' fact is defined. couchdblookup() will not return what you expect !")
-      return default ? default : :undef
+    begin
+      if lookupvar('vagrantbox') == true
+        Puppet.send(:warning, "Bypassing couchdb lookup because 'vagrantbox' fact is defined. couchdblookup() will not return what you expect !")
+        return default ? default : :undef
+      end
+    rescue Puppet::ParseError
+      # do nothing
     end
 
     begin


### PR DESCRIPTION
lookupvar() throws Puppet::ParseError when strict_variables is enabled we have to catch and ignore it.
