### PR TITLE
Support RedHat OS family, not just RedHat.  Fail when OS not supported

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,13 +4,18 @@ class couchdb (
   $backupdir = $couchdb::params::backupdir,
 ) inherits ::couchdb::params {
 
-  case $::operatingsystem {
+  case $::osfamily {
     Debian: {
       case $::lsbdistcodename {
         /lenny|squeeze|wheezy/: { include ::couchdb::debian }
-        default: { fail "couchdb not available for ${::operatingsystem}/${::lsbdistcodename}" }
+        default: {
+          fail(
+            "couchdb unavailable for ${::operatingsystem}/${::lsbdistcodename}"
+          )
+        }
       }
     }
-    RedHat: { include ::couchdb::redhat }
+    RedHat:  { include ::couchdb::redhat }
+    default: { fail "couchdb not available for ${::operatingsystem}" }
   }
 }


### PR DESCRIPTION
init class should not fail silently when OS not supported.  Easy to support CentOS (et al) with RedHat clause in $::osfamily.
