### PR TITLE
Make service configurable

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,13 +1,16 @@
-class couchdb::base {
+class couchdb::base (
+  $service_enable,
+  $service_ensure,
+) {
 
   package {'couchdb':
     ensure => present,
   }
 
   service {'couchdb':
-    ensure    => running,
+    enable    => $service_enable,
+    ensure    => $service_ensure,
     hasstatus => true,
-    enable    => true,
     require   => Package['couchdb'],
   }
 

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -7,9 +7,15 @@ class couchdb::base (
     ensure => present,
   }
 
+  if $service_ensure == 'unmanaged' {
+    $_service_ensure = undef
+  } else {
+    $_service_ensure = $service_ensure
+  }
+
   service {'couchdb':
     enable    => $service_enable,
-    ensure    => $service_ensure,
+    ensure    => $_service_ensure,
     hasstatus => true,
     require   => Package['couchdb'],
   }

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -1,5 +1,11 @@
-class couchdb::debian {
-  include ::couchdb::base
+class couchdb::debian (
+  $service_ensure,
+  $service_enable,
+) {
+  class { '::couchdb::base':
+    service_ensure => $service_ensure,
+    service_enable => $service_enable,
+  }
 
   package {'libjs-jquery':
     ensure => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,11 +2,23 @@ class couchdb (
   $bind_address = $couchdb::params::bind_address,
   $port = $couchdb::params::port,
   $backupdir = $couchdb::params::backupdir,
+  $service_ensure = $couchdb::params::service_ensure,
+  $service_enable = $couchdb::params::service_enable,
 ) inherits ::couchdb::params {
 
   case $::osfamily {
-    'Debian': { include ::couchdb::debian }
-    'RedHat': { include ::couchdb::redhat }
+    'Debian': {
+      class { '::couchdb::debian':
+        service_ensure => $service_ensure,
+        service_enable => $service_enable,
+      }
+    }
+    'RedHat': {
+      class { '::couchdb::redhat':
+        service_ensure => $service_ensure,
+        service_enable => $service_enable,
+      }
+    }
     default:  { fail "couchdb not available for ${::operatingsystem}" }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,4 +20,7 @@ class couchdb::params {
 
   $backupdir = '/var/backups/couchdb'
 
+  $service_enable = true
+
+  $service_ensure = 'running'
 }

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -1,3 +1,6 @@
 class couchdb::redhat {
-  include ::couchdb::base
+  class { '::couchdb::base':
+    service_ensure => $service_ensure,
+    service_enable => $service_enable,
+  }
 }


### PR DESCRIPTION
To store CouchDB data on an encrypted disk which is not available right after startup (requires manual intervention), we must be able to prevent the service from starting at boot and prevent Puppet from starting (or stopping) the service after boot. 